### PR TITLE
Fix that allows program optimization

### DIFF
--- a/Example/HWSyscalls-Example/HWSyscalls-Example.vcxproj
+++ b/Example/HWSyscalls-Example/HWSyscalls-Example.vcxproj
@@ -130,8 +130,9 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <Optimization>Disabled</Optimization>
+      <Optimization>MaxSpeed</Optimization>
       <LanguageStandard>stdcpp20</LanguageStandard>
+      <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/Example/HWSyscalls-Example/HWSyscalls.cpp
+++ b/Example/HWSyscalls-Example/HWSyscalls.cpp
@@ -183,9 +183,11 @@ DWORD64 FindSyscallReturnAddress(DWORD64 functionAddress, WORD syscallNumber) {
 
 #pragma endregion
 
+#pragma optimize("", off)
 UINT64 PrepareSyscall(char* functionName) {
     return ntFunctionAddress;
 }
+#pragma optimize("", on)
 
 bool SetMainBreakpoint() {
     // Dynamically find the GetThreadContext and SetThreadContext functions

--- a/README.md
+++ b/README.md
@@ -91,9 +91,7 @@ The debug verbosity can be turned on or off by changing the `HWSYSCALLS_DEBUG` d
 
 ## Setup
 
-To compile this project you will need Visual Studio 2019 and forward.
-It is important to note that this project was made only for x64 environments and needs to be compiled without optimization.
-You can disable it from Project Settings -> C/C++ -> Optimization -> Optimization (Disabled /Od).
+To compile this project you will need Visual Studio 2019 and forward. Furthermore, it is important to note that this project was made only for x64 environments.
 
 ## Example
 

--- a/Src/HWSyscalls.cpp
+++ b/Src/HWSyscalls.cpp
@@ -183,9 +183,11 @@ DWORD64 FindSyscallReturnAddress(DWORD64 functionAddress, WORD syscallNumber) {
 
 #pragma endregion
 
+#pragma optimize("", off)
 UINT64 PrepareSyscall(char* functionName) {
     return ntFunctionAddress;
 }
+#pragma optimize("", on)
 
 bool SetMainBreakpoint() {
     // Dynamically find the GetThreadContext and SetThreadContext functions


### PR DESCRIPTION
Hello,

I noticed that the only function that doesn't accept optimization is PrepareSyscall(), by deactivating the optimization at compile-time for that function only with the "optimize" pragma directive it is possible to allow optimizing the rest of the program. 

Tested it with /GL as well as /O2, /O1, and /Ox.